### PR TITLE
ESLint rules enforcing ES2015

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
         ],
         "quotes": [
             2,
-            "single"
+            "double"
         ],
         "linebreak-style": [
             2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+    "plugins": [
+        "react"
+    ],
     "extends": "google",
     "parser": "babel-eslint",
     "rules": {
@@ -18,6 +21,9 @@
             2,
             "always"
         ],
+        "no-var": 2,
+        "prefer-const": 2,
+        "prefer-arrow-callback": 2,
         "dot-location": [2, "property"],
         "max-len": 0,
         "no-extra-parens": 0,
@@ -62,11 +68,10 @@
         "commonjs": true,
         "mocha": true
     },
-    "ecmaFeatures": {
-        "jsx": true,
-        "experimentalObjectRestSpread": true
-    },
-    "plugins": [
-        "react"
-    ]
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true,
+            "experimentalObjectRestSpread": true
+        }
+    }
 }

--- a/spec/components/code-crawl-spec.js
+++ b/spec/components/code-crawl-spec.js
@@ -1,17 +1,17 @@
-import React from 'react';
-import TestUtils from 'react-addons-test-utils';
-import expect from 'expect';
-import expectJSX from 'expect-jsx';
+import React from "react";
+import TestUtils from "react-addons-test-utils";
+import expect from "expect";
+import expectJSX from "expect-jsx";
 
 expect.extend(expectJSX);
 
-import CodeCrawl from '../../src/components/code-crawl';
+import CodeCrawl from "../../src/components/code-crawl";
 
-describe('CodeCrawl', () => {
-  it('should render prop test in h1', () => {
+describe("CodeCrawl", () => {
+  it("should render prop test in h1", () => {
     const renderer = TestUtils.createRenderer();
 
-    const text = 'This is some sample text';
+    const text = "This is some sample text";
 
     renderer.render(<CodeCrawl text={text} />);
 

--- a/spec/components/hello-world-spec.js
+++ b/spec/components/hello-world-spec.js
@@ -1,14 +1,14 @@
-import React from 'react';
-import TestUtils from 'react-addons-test-utils';
-import expect from 'expect';
-import expectJSX from 'expect-jsx';
+import React from "react";
+import TestUtils from "react-addons-test-utils";
+import expect from "expect";
+import expectJSX from "expect-jsx";
 
 expect.extend(expectJSX);
 
-import HelloWorld from '../../src/components/hello-world';
+import HelloWorld from "../../src/components/hello-world";
 
-describe('HelloWorld', () => {
-  it('should show correct greeting', () => {
+describe("HelloWorld", () => {
+  it("should show correct greeting", () => {
     const renderer = TestUtils.createRenderer();
 
     renderer.render(<HelloWorld name="Krabba" />);

--- a/spec/components/matrix-spec.js
+++ b/spec/components/matrix-spec.js
@@ -1,18 +1,18 @@
-import React from 'react';
+import React from "react";
 
-import TestUtils from 'react-addons-test-utils';
-import expect from 'expect';
-import expectJSX from 'expect-jsx';
+import TestUtils from "react-addons-test-utils";
+import expect from "expect";
+import expectJSX from "expect-jsx";
 
 expect.extend(expectJSX);
 
-import Matrix from '../../src/components/matrix';
+import Matrix from "../../src/components/matrix";
 
-describe('Matrix', () => {
-  it('should render an h4 with user name', () => {
+describe("Matrix", () => {
+  it("should render an h4 with user name", () => {
     const renderer = TestUtils.createRenderer();
 
-    const fakeData = [{id: 1, user: 'Lord Howell', commit: 'Some text'}];
+    const fakeData = [{id: 1, user: "Lord Howell", commit: "Some text"}];
 
     renderer.render(<Matrix data={fakeData} />);
 

--- a/spec/components/screaming-hello-world-spec.js
+++ b/spec/components/screaming-hello-world-spec.js
@@ -1,14 +1,14 @@
-import React from 'react';
-import TestUtils from 'react-addons-test-utils';
-import expect from 'expect';
-import expectJSX from 'expect-jsx';
+import React from "react";
+import TestUtils from "react-addons-test-utils";
+import expect from "expect";
+import expectJSX from "expect-jsx";
 
 expect.extend(expectJSX);
 
-import ScreamingHelloWorld from '../../src/components/screaming-hello-world.js';
+import ScreamingHelloWorld from "../../src/components/screaming-hello-world.js";
 
-describe('ScreamingHelloWorld', () => {
-  it('this one screams', () => {
+describe("ScreamingHelloWorld", () => {
+  it("this one screams", () => {
     const renderer = TestUtils.createRenderer();
 
     renderer.render(<ScreamingHelloWorld name="mattias" />);

--- a/spec/components/settings-spec.js
+++ b/spec/components/settings-spec.js
@@ -1,36 +1,36 @@
-import React from 'react';
-import TestUtils from 'react-addons-test-utils';
-import expect from 'expect';
-import expectJSX from 'expect-jsx';
-import ReactWarnings from '../helpers/react-warnings';
+import React from "react";
+import TestUtils from "react-addons-test-utils";
+import expect from "expect";
+import expectJSX from "expect-jsx";
+import ReactWarnings from "../helpers/react-warnings";
 
 expect.extend(expectJSX);
 
-import Settings from '../../src/components/settings';
+import Settings from "../../src/components/settings";
 
-describe('Settings component', () => {
+describe("Settings component", () => {
   beforeEach(() => ReactWarnings.watchConsole());
 
   afterEach(() => expect(ReactWarnings.propWarnings().length).toBe(0));
 
-  it('should render an input field with correct type and ref', () => {
+  it("should render an input field with correct type and ref", () => {
     const renderer = TestUtils.createRenderer();
 
-    renderer.render(<Settings settings={{time: 0}} routes={[{path: 'somewhere'}]} />);
+    renderer.render(<Settings settings={{time: 0}} routes={[{path: "somewhere"}]} />);
 
     const actual = renderer.getRenderOutput();
     const expected = <input type="number" ref="seconds" />;
 
     expect(actual).toIncludeJSX(expected);
   });
-  it('should render a checkbox for each route sent in through the routes-prop', () => {
+  it("should render a checkbox for each route sent in through the routes-prop", () => {
     const renderer = TestUtils.createRenderer();
     const routes = [{
-      path: 'pathOne'
+      path: "pathOne"
     }, {
-      path: 'pathTwo'
+      path: "pathTwo"
     }, {
-      path: 'pathThree'
+      path: "pathThree"
     }];
 
     renderer.render(<Settings settings={{time: 0}} routes={routes} />);

--- a/spec/components/settings-spec.js
+++ b/spec/components/settings-spec.js
@@ -36,8 +36,7 @@ describe("Settings component", () => {
     renderer.render(<Settings settings={{time: 0}} routes={routes} />);
 
     const actual = renderer.getRenderOutput();
-    const expected = (
-      <span>
+    const expected = (<span>
         <label><input ref="pathOne" name="pathOne" type="checkbox" />pathOne</label>
         <label><input ref="pathTwo" name="pathTwo" type="checkbox" />pathTwo</label>
         <label><input ref="pathThree" name="pathThree" type="checkbox" />pathThree</label>

--- a/spec/components/sphere-spec.js
+++ b/spec/components/sphere-spec.js
@@ -1,16 +1,16 @@
-import React from 'react';
-import TestUtils from 'react-addons-test-utils';
-import expect from 'expect';
-import expectJSX from 'expect-jsx';
+import React from "react";
+import TestUtils from "react-addons-test-utils";
+import expect from "expect";
+import expectJSX from "expect-jsx";
 
 expect.extend(expectJSX);
 
-import Sphere from '../../src/components/sphere.js';
+import Sphere from "../../src/components/sphere.js";
 
-describe('Sphere', () => {
-  it('Renders a div with correct id', () => {
+describe("Sphere", () => {
+  it("Renders a div with correct id", () => {
     const renderer = TestUtils.createRenderer();
-    const expectedID = 'sphere-container';
+    const expectedID = "sphere-container";
 
     renderer.render(<Sphere data={[{lat: 1, lng: 2, time: 3}]} />);
 

--- a/spec/helpers/react-warnings.js
+++ b/spec/helpers/react-warnings.js
@@ -1,10 +1,10 @@
 // Found at: https://medium.com/about-codecademy/proptypes-validation-in-react-karma-683c7d52abe#.vxn0s7u9v
-import {spyOn} from 'expect';
+import {spyOn} from "expect";
 
 export default {
   spy: null,
   watchConsole() {
-    this.spy = spyOn(console, 'error');
+    this.spy = spyOn(console, "error");
   },
   propWarnings() {
     const propWarnings = this.spy.calls.filter(c => {

--- a/spec/helpers/react-warnings.js
+++ b/spec/helpers/react-warnings.js
@@ -8,9 +8,9 @@ export default {
   },
   propWarnings() {
     const propWarnings = this.spy.calls.filter(c => {
-      return (c.arguments &&
+      return c.arguments &&
       c.arguments.length > 0 &&
-      /(Invalid prop|Failed propType)/.test(c.arguments[0]));
+      /(Invalid prop|Failed propType)/.test(c.arguments[0]);
     });
 
     return propWarnings;

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,4 +1,4 @@
-import settings from './settings';
+import settings from "./settings";
 
 export default Object.assign(
   {},

--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -1,5 +1,5 @@
 // import C from '../constants';
-import {hashHistory} from 'react-router';
+import {hashHistory} from "react-router";
 
 export default {
   saveAndStart(settings) {

--- a/src/components/code-crawl.js
+++ b/src/components/code-crawl.js
@@ -1,12 +1,12 @@
-import React, {Component} from 'react';
-import {hashHistory} from 'react-router';
+import React, {Component} from "react";
+import {hashHistory} from "react-router";
 
 export default class CodeCrawl extends Component {
   componentDidMount() {
     console.log(hashHistory);
   }
   clickHandler() {
-    hashHistory.push('sphere');
+    hashHistory.push("sphere");
   }
   render() {
     return (

--- a/src/components/code.js
+++ b/src/components/code.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 export default class Code extends React.Component {
   render() {
     return (

--- a/src/components/hello-world.js
+++ b/src/components/hello-world.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component} from "react";
 
 export default class HelloWorld extends Component {
   render() {

--- a/src/components/matrix.js
+++ b/src/components/matrix.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from "react";
 
-import Code from './code';
+import Code from "./code";
 
 export default class Commit extends React.Component {
 

--- a/src/components/matrix.js
+++ b/src/components/matrix.js
@@ -5,7 +5,7 @@ import Code from "./code";
 export default class Commit extends React.Component {
 
   getData() {
-    let dataComponents = this.props.data.map(function(data) {
+    const dataComponents = this.props.data.map(data => {
       return (
         <div key={data.id}>
           <h4>{data.user}</h4>

--- a/src/components/screaming-hello-world.js
+++ b/src/components/screaming-hello-world.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component} from "react";
 
 export default class ScreamingHelloWorld extends Component {
   render() {

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -1,11 +1,11 @@
-import React, {Component} from 'react';
-import filter from 'lodash/filter';
+import React, {Component} from "react";
+import filter from "lodash/filter";
 
 export default class Settings extends Component {
   saveSettings(e) {
     e.preventDefault();
 
-    const pathsToVisit = filter(this.refs, r => r.type === 'checkbox' && r.checked).map(r => r.name);
+    const pathsToVisit = filter(this.refs, r => r.type === "checkbox" && r.checked).map(r => r.name);
     const time = this.refs.seconds.value;
     const settings = {
       pathsToVisit,
@@ -15,7 +15,7 @@ export default class Settings extends Component {
     this.props.saveAndStart(settings);
   }
   render() {
-    const routes = this.props.routes.filter(r => r.path !== 'settings'); // remove current settings path from array
+    const routes = this.props.routes.filter(r => r.path !== "settings"); // remove current settings path from array
 
     // console.log(routes);
 

--- a/src/components/sphere.js
+++ b/src/components/sphere.js
@@ -20,8 +20,8 @@
  *      ];
  */
 
-import React, {Component} from 'react';
-import THREE from 'three';
+import React, {Component} from "react";
+import THREE from "three";
 
 export default class Sphere extends Component {
   constructor() {
@@ -32,7 +32,7 @@ export default class Sphere extends Component {
   componentDidMount() {
     const width = window.innerWidth;
     const height = window.innerHeight;
-    const container = document.getElementById('sphere-container');
+    const container = document.getElementById("sphere-container");
     const camera = new THREE.PerspectiveCamera(75, width / height, 1, 1000);
     const scene = new THREE.Scene();
     const renderer = new THREE.WebGLRenderer();

--- a/src/components/sphere.js
+++ b/src/components/sphere.js
@@ -49,7 +49,7 @@ export default class Sphere extends Component {
     });
 
     for (let i = 0; i < 1000; i += 1) {
-      let particle = new THREE.Sprite(material);
+      const particle = new THREE.Sprite(material);
 
       particle.position.x = Math.random() * 2 - 1;
       particle.position.y = Math.random() * 2 - 1;
@@ -73,7 +73,7 @@ export default class Sphere extends Component {
             return;
           }
 
-          let lineLength = 1 - (this.time + c.time) / 5000.0;
+          const lineLength = 1 - (this.time + c.time) / 5000.0;
 
           if (lineLength < 0) {
             return;
@@ -119,7 +119,7 @@ export default class Sphere extends Component {
   }
 
   render() {
-    return (<div id="sphere-container" />);
+    return <div id="sphere-container" />;
   }
 }
 

--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -1,5 +1,5 @@
 import React from "react";
 
-const Wrapper = props => (<div className="wrapper">{props.children}</div>);
+const Wrapper = props => <div className="wrapper">{props.children}</div>;
 
 export default Wrapper;

--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 const Wrapper = props => (<div className="wrapper">{props.children}</div>);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 const C = {
-  STOP_SPHERE: 'STOP_SPHERE'
+  STOP_SPHERE: "STOP_SPHERE"
 };
 
 export default C;

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
-import React from 'react';
-import ReactDom from 'react-dom';
-import {Router, hashHistory} from 'react-router';
-import {Provider} from 'react-redux';
-import store from './store';
-import routes from './routes';
+import React from "react";
+import ReactDom from "react-dom";
+import {Router, hashHistory} from "react-router";
+import {Provider} from "react-redux";
+import store from "./store";
+import routes from "./routes";
 
 // By wrapping the whole app in the react-redux Provider we get... magic!
 ReactDom.render(
   <Provider store={store}>
     <Router history={hashHistory} routes={routes} />
   </Provider>,
-  document.getElementById('root')
+  document.getElementById("root")
 );

--- a/src/pages/code-crawl-page.js
+++ b/src/pages/code-crawl-page.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import {connect} from 'react-redux';
-import CodeCrawl from '../components/code-crawl';
+import React from "react";
+import {connect} from "react-redux";
+import CodeCrawl from "../components/code-crawl";
 
 const CodeCrawlPage = ({text}) => (<CodeCrawl text={text} />);
 

--- a/src/pages/code-crawl-page.js
+++ b/src/pages/code-crawl-page.js
@@ -2,7 +2,7 @@ import React from "react";
 import {connect} from "react-redux";
 import CodeCrawl from "../components/code-crawl";
 
-const CodeCrawlPage = ({text}) => (<CodeCrawl text={text} />);
+const CodeCrawlPage = ({text}) => <CodeCrawl text={text} />;
 
 const mapStateToProps = appState => {
   return {

--- a/src/pages/matrix-page.js
+++ b/src/pages/matrix-page.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import {connect} from 'react-redux';
-import Matrix from '../components/matrix';
+import React from "react";
+import {connect} from "react-redux";
+import Matrix from "../components/matrix";
 
 const MatrixPage = ({data}) => (<Matrix data={data} />);
 

--- a/src/pages/matrix-page.js
+++ b/src/pages/matrix-page.js
@@ -2,7 +2,7 @@ import React from "react";
 import {connect} from "react-redux";
 import Matrix from "../components/matrix";
 
-const MatrixPage = ({data}) => (<Matrix data={data} />);
+const MatrixPage = ({data}) => <Matrix data={data} />;
 
 const mapStateToProps = appState => {
   return {

--- a/src/pages/settings-page.js
+++ b/src/pages/settings-page.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import {connect} from 'react-redux';
-import actions from '../actions';
-import Settings from '../components/settings';
+import React from "react";
+import {connect} from "react-redux";
+import actions from "../actions";
+import Settings from "../components/settings";
 
 const SettingsPage = ({settings, routes, saveAndStart}) => (<Settings saveAndStart={saveAndStart} settings={settings} routes={routes[0].childRoutes} />);
 

--- a/src/pages/settings-page.js
+++ b/src/pages/settings-page.js
@@ -3,7 +3,7 @@ import {connect} from "react-redux";
 import actions from "../actions";
 import Settings from "../components/settings";
 
-const SettingsPage = ({settings, routes, saveAndStart}) => (<Settings saveAndStart={saveAndStart} settings={settings} routes={routes[0].childRoutes} />);
+const SettingsPage = ({settings, routes, saveAndStart}) => <Settings saveAndStart={saveAndStart} settings={settings} routes={routes[0].childRoutes} />;
 
 const mapStateToProps = appState => {
   return {

--- a/src/pages/sphere-page.js
+++ b/src/pages/sphere-page.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import {connect} from 'react-redux';
-import Sphere from '../components/sphere';
+import React from "react";
+import {connect} from "react-redux";
+import Sphere from "../components/sphere";
 
 // Since a few versions back you can create React components that don't
 // have any state or don't use any of the lifecycle methods (like componentDidMount)

--- a/src/pages/sphere-page.js
+++ b/src/pages/sphere-page.js
@@ -7,7 +7,7 @@ import Sphere from "../components/sphere";
 // as simple functions that gets their props sent in as parameters.
 // For more info see: https://facebook.github.io/react/docs/reusable-components.html#stateless-functions
 
-const SpherePage = ({data}) => (<Sphere data={data} />);
+const SpherePage = ({data}) => <Sphere data={data} />;
 // This is one of those stateless functions with some extra pizazz added by doing
 // some object destructuring on the props. The code above is equal to doing this:
 // const SpherePage = (props) => (<Sphere data={props.data} />);

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,11 +1,11 @@
-import React from 'react';
-import {Route, IndexRoute} from 'react-router';
+import React from "react";
+import {Route, IndexRoute} from "react-router";
 
-import Wrapper from './components/wrapper';
-import CodeCrawlPage from './pages/code-crawl-page';
-import SettingsPage from './pages/settings-page';
-import SpherePage from './pages/sphere-page';
-import MatrixPage from './pages/matrix-page';
+import Wrapper from "./components/wrapper";
+import CodeCrawlPage from "./pages/code-crawl-page";
+import SettingsPage from "./pages/settings-page";
+import SpherePage from "./pages/sphere-page";
+import MatrixPage from "./pages/matrix-page";
 
 export default (
   <Route path="/" component={Wrapper}>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,18 +1,18 @@
-import {applyMiddleware, createStore} from 'redux';
-import {hashHistory} from 'react-router';
-import thunk from 'redux-thunk';
-import {syncHistory} from 'react-router-redux';
+import {applyMiddleware, createStore} from "redux";
+import {hashHistory} from "react-router";
+import thunk from "redux-thunk";
+import {syncHistory} from "react-router-redux";
 
-import rootReducer from './reducers';
-import initialState from './initial-state';
+import rootReducer from "./reducers";
+import initialState from "./initial-state";
 
 const reduxRouterMiddleware = syncHistory(hashHistory);
 
 const logger = store => next => action => {
-  console.log('dispatching', action.type, action);
+  console.log("dispatching", action.type, action);
   const result = next(action);
 
-  console.log('next state', store.getState());
+  console.log("next state", store.getState());
   return result;
 };
 

--- a/src/store/initial-state.js
+++ b/src/store/initial-state.js
@@ -2,12 +2,12 @@ export default {
   matrix: {
     data: [{
       id: 1,
-      user: 'sonny',
-      commit: 'if (hej) {drink.Coffe()}'
+      user: "sonny",
+      commit: "if (hej) {drink.Coffe()}"
     }, {
       id: 2,
-      user: 'Lord Howell',
-      commit: 'if (morning) {goto Work}'
+      user: "Lord Howell",
+      commit: "if (morning) {goto Work}"
     }]
   },
   settings: {
@@ -25,6 +25,6 @@ export default {
     ]
   },
   codeCrawl: {
-    text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eligendi officia adipisci numquam eos sit. Autem vitae accusamus corporis laudantium ipsa ad impedit, quis possimus omnis rem excepturi illo sunt reprehenderit!'
+    text: "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eligendi officia adipisci numquam eos sit. Autem vitae accusamus corporis laudantium ipsa ad impedit, quis possimus omnis rem excepturi illo sunt reprehenderit!"
   }
 };

--- a/src/store/reducers/code-crawl.js
+++ b/src/store/reducers/code-crawl.js
@@ -1,5 +1,5 @@
 // import C from '../../constants';
-import initialState from '../initial-state';
+import initialState from "../initial-state";
 
 export default (currentState = initialState.codeCrawl, action) => {
   switch (action.type) {

--- a/src/store/reducers/index.js
+++ b/src/store/reducers/index.js
@@ -1,11 +1,11 @@
-import {combineReducers} from 'redux';
-import {routeReducer} from 'react-router-redux';
+import {combineReducers} from "redux";
+import {routeReducer} from "react-router-redux";
 
 // These are the different reducers for the application
-import codeCrawl from './code-crawl';
-import settings from './settings';
-import sphere from './sphere';
-import matrix from './matrix';
+import codeCrawl from "./code-crawl";
+import settings from "./settings";
+import sphere from "./sphere";
+import matrix from "./matrix";
 
 // Look, es2015 sexy object literals!
 // {sphere: sphere} === {sphere}

--- a/src/store/reducers/matrix.js
+++ b/src/store/reducers/matrix.js
@@ -1,4 +1,4 @@
-import initialState from '../initial-state';
+import initialState from "../initial-state";
 
 export default (currentState = initialState.matrix, action) => {
   switch (action.type) {

--- a/src/store/reducers/settings.js
+++ b/src/store/reducers/settings.js
@@ -1,4 +1,4 @@
-import initialState from '../initial-state';
+import initialState from "../initial-state";
 
 export default (currentState = initialState.settings, action) => {
   switch (action.type) {

--- a/src/store/reducers/sphere.js
+++ b/src/store/reducers/sphere.js
@@ -1,5 +1,5 @@
 // import C from '../../constants';
-import initialState from '../initial-state';
+import initialState from "../initial-state";
 
 export default (currentState = initialState.sphere, action) => {
   switch (action.type) {


### PR DESCRIPTION
This pull request adds the three rules [no-vars](http://eslint.org/docs/rules/no-var), [prefer-const](http://eslint.org/docs/rules/prefer-const), [prefer-arrow-callback](http://eslint.org/docs/rules/prefer-arrow-callback) to the ESLint configuration. What these three rules do is enforce the use of some nice ES2015 features.

I was just looking through the ESLint rules documentation and thought these were pretty cool and a good way to get into using the new stuff, but it is of course something we should decide if we want as a group. So what do you think @rk222ev and @sk222sw, are these OK or just too opinionated?
