### PR TITLE
Move eslint config google to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "eslint": "^2.2.0",
+    "eslint-config-google": "^0.4.0",
     "eslint-loader": "^1.2.0",
     "eslint-plugin-react": "^3.16.1",
     "http-server": "^0.8.5",
@@ -54,7 +55,6 @@
     "webpack-dev-server": "^1.14.1"
   },
   "devDependencies": {
-    "eslint-config-google": "^0.4.0",
     "eslint-config-xo": "^0.10.1",
     "expect": "^1.13.4",
     "expect-jsx": "^2.2.2",


### PR DESCRIPTION
A preloader in the webpack config preruns eslint on builds.
Heroku doesn't install dev dependencies by default and eslint
depends on the eslint-config-google package that was declared
as a dev dependency.
