### PR TITLE
Remove global css rules as it affecting other pages

### DIFF
--- a/assets/matrix.css
+++ b/assets/matrix.css
@@ -2,22 +2,12 @@
 @import url("//fonts.googleapis.com/css?family=Catamaran:400,900");
 /*@import url("//fonts.googleapis.com/css?family=Martel+Sans:400,900");*/
 
-* {
-    overflow: hidden;
-}
-
-body {
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 1);
-    color: white;
-}
-
 /* MATRIX VISUALIZATION SECTION */
 
 .matrix-visualization {
     width: 100%;
     height: 100%;
+    background: rgba(0, 0, 0, 1);
 }
 
 .matrix-code-section {
@@ -82,3 +72,4 @@ body {
 }
 .contributor {
 }
+


### PR DESCRIPTION
This commit removes some css rules that had a global effect.
The settings page was unreadable and it hides overflow on all elements on all pages. This could be a problem writing other components where this would be the expected and/or needed behaviour.

Should overflow: hidden be needed please apply in a non global way.

As far as I could see there were no white text in the matrix component so removed that one as it seems to be unused.
