### PR TITLE
Build production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bundle.js
 
 # webstorm directory
 .idea
+build/
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "c9-start": "webpack-dev-server --host $IP --port $PORT --hot --inline --progress --colors -d",
     "build": "webpack --progress",
     "build:production": "webpack --progress -p --config ./webpack.config.production",
-    "postbuild:production": "mkdir -p build && cp -r ./assets index.html bundle.js build"
+    "postbuild:production": "mkdir -p build && cp -r ./assets index.html bundle.js build",
+    "clean": "rm -r ./build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "webpack-dev-server --hot --inline --progress --colors -d",
     "c9-start": "webpack-dev-server --host $IP --port $PORT --hot --inline --progress --colors -d",
     "build": "webpack --progress",
-    "build:production": "webpack --progress -p --config ./webpack.config.production"
+    "build:production": "webpack --progress -p --config ./webpack.config.production",
+    "postbuild:production": "mkdir -p build && cp -r ./assets index.html bundle.js build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a post script to build:production where a folder named ./build will be created (if it doesn't exist) and then ./assets, index.html and bundle.js will be copied to ./build.
This will make deployment easy as all needed files are contained to ./build.

This also adds npm run clean that removes the ./build folder.
