### PR TITLE
Reverse order of position data after unannounced backend change

### DIFF
--- a/src/components/earth.js
+++ b/src/components/earth.js
@@ -63,7 +63,8 @@ export default class Earth extends Component {
   }
 
   startAnimation(nextProps) {
-    const time = nextProps.data[nextProps.data.length - 1].time;
+    const reversedArray = nextProps.data.reverse();
+    const time = reversedArray[nextProps.data.length - 1].time;
     this.setState({time});
 
     const animationLoop = () => {


### PR DESCRIPTION
As the sorting of events changed I now reverse the position to get a proper timeline going.
